### PR TITLE
Update libxml2-markup.h

### DIFF
--- a/Modules/libxml2-markup.h
+++ b/Modules/libxml2-markup.h
@@ -1,13 +1,13 @@
 #ifndef LIBXML2_MARKUP_H
 #define LIBXML2_MARKUP_H
-#import <libxml2/libxml/tree.h>
-#import <libxml2/libxml/xmlreader.h>
-#import <libxml2/libxml/xpath.h>
-#import <libxml2/libxml/xpathInternals.h>
-#import <libxml2/libxml/HTMLtree.h>
-#import <libxml2/libxml/HTMLparser.h>
-#import <libxml2/libxml/parser.h>
-#import <libxml2/libxml/entities.h>
-#import <libxml2/libxml/SAX.h>
-#import <libxml2/libxml/SAX2.h>
+#include <libxml2/libxml/tree.h>
+#include <libxml2/libxml/xmlreader.h>
+#include <libxml2/libxml/xpath.h>
+#include <libxml2/libxml/xpathInternals.h>
+#include <libxml2/libxml/HTMLtree.h>
+#include <libxml2/libxml/HTMLparser.h>
+#include <libxml2/libxml/parser.h>
+#include <libxml2/libxml/entities.h>
+#include <libxml2/libxml/SAX.h>
+#include <libxml2/libxml/SAX2.h>
 #endif /* LIBXML2_MARKUP_H */


### PR DESCRIPTION
`#import` is not valid C/C++.  It is an Objective-C extension, which is non-portable.  On Windows, `#import` is a non-portable extension which imports type libraries.  Convert to using standard C/C++ for C modules.  This is required to build this project on Windows.