### PR TITLE
Update Node.swift

### DIFF
--- a/Sources/DOM/Node.swift
+++ b/Sources/DOM/Node.swift
@@ -7,7 +7,7 @@ open class Node: RawRepresentable, Equatable, Hashable, CustomStringConvertible 
     }
     
     public var line: Int {
-        return xmlGetLineNo(xmlNode)
+        return numericCast(xmlGetLineNo(xmlNode))
     }
 
     public var isBlank: Bool {


### PR DESCRIPTION
`xmlGetLineNo` is defined as a function returning a `Long`.  The correct type to map that to Swift is `CLong`.  Due to the differences in LP64 and LLP64, `long` is not mapped equivalently on all environments.  However, to maintain the API, use a `numericCast` to convert the integral type from any compatible type from the C interface.