### PR TITLE
Modules: repair libxml2 link on Windows

### DIFF
--- a/Modules/libxml2-markup.h
+++ b/Modules/libxml2-markup.h
@@ -10,4 +10,31 @@
 #include <libxml2/libxml/entities.h>
 #include <libxml2/libxml/SAX.h>
 #include <libxml2/libxml/SAX2.h>
+
+#if defined(_WIN32)
+# if defined(LIBXML_STATIC)
+#   if defined(LIBXML_DEBUG)
+#     pragma comment(lib, "libxml2sd.lib")
+#   else
+#     pragma comment(lib, "libxml2s.lib")
+#   endif
+# else
+#   if defined(LIBXML_DEBUG)
+#     pragma comment(lib, "xml2d.lib")
+#   else
+#     pragma comment(lib, "xml2.lib")
+#   endif
+# endif
+#elif defined(__ELF__)
+__asm__ (".section .swift1_autolink_entries,\"a\",@progbits\n"
+         ".p2align 3\n"
+         ".L_swift1_autolink_entries:\n"
+         "  .asciz \"-lxml2\"\n"
+         "  .size .L_swift1_autolink_entries, 7\n");
+#elif defined(__wasm__)
+#warning WASM autolinking not implemented
+#else /* assume MachO */
+__asm__ (".linker_option \"-lxml2\"\n");
+#endif
+
 #endif /* LIBXML2_MARKUP_H */

--- a/Modules/module.modulemap
+++ b/Modules/module.modulemap
@@ -1,5 +1,4 @@
 module libxml2 [system] {
-    link "xml2"
     umbrella header "libxml2-markup.h"
     export *
     module * { export * }


### PR DESCRIPTION
We cannot simply explicitly spell out the linked library name in
general.  On Windows, the name of the library is determined by the
library in use and selects across the following matrix:

| | Debug | Release |
| --- | --- | --- |
| **Static** | `libxml2sd.lib` | `libxml2s.lib` |
| **Dynamic** | `xml2d.lib` | `xml2.lib` |

Note that this already assumes that the dynamic MSVC library (`/MD`)
build is in use.  The selection between `/MD` and `/MT` is not something
that can be identified by the name.

Accommodating this within the modulemap is not entirely reasonable.  As
a result, in order to maintain compatibility with the current behaviour,
I've resorted to some module level inline assembly (simply to avoid
adding a source file as there is no source file currently for the
module).  By hand constructing the linker directives for Linux and
macOS, we can continue to have the autolinking behaviour which can
support all the platforms.

The alternative to all this mess would be to require the user to specify
the location of the import library, DSO, or TBD (depending on the
platform) manually when invoking the swift build tool.